### PR TITLE
Additional input checks for grpSLOPE() function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,3 +3,7 @@ This is a list of API changes.
 # grpSLOPE 0.2.0.9000
 
 * Fix for the installation error on r-oldrel-windows-ix86+x86_64 (R v3.2.5) in the CRAN package check results. This error was caused by the generic S3 method `sigma()` not being available from the `stats` package prior to R v3.3.0.
+
+* Checks for missing data in the inputs X, y and group were added in grpSLOPE().
+
+* A check for whether the input matrix X has columns with 0 variance is performed in grpSLOPE() when normalize=TRUE. This should prevent division by 0, when the columns of X are standardized to have norms equal to 1.

--- a/tests/testthat/test_grpSLOPE.R
+++ b/tests/testthat/test_grpSLOPE.R
@@ -76,6 +76,56 @@ test_that("corrected lambdas can't be computed unless groups sizes are small eno
                regexp = "Corrected lambdas cannot be computed unless groups sizes are small enough compared to sample size.")
 })
 
+test_that("an error message is returned when inputs have missing data", {
+  # NA in X
+  Xcorrupted <- A
+  ind1 <- sample(1:nrow(Xcorrupted), 3)
+  ind2 <- sample(1:ncol(Xcorrupted), 2)
+  Xcorrupted[ind1, ind2] <- NA
+  expect_error(grpSLOPE(X=Xcorrupted, y=y, group=grp, fdr=fdr, lambda="corrected"),
+               regexp = "Some entries of X are NA or NaN!")
+  # NaN in X
+  Xcorrupted <- A
+  ind1 <- sample(1:nrow(Xcorrupted), 3)
+  ind2 <- sample(1:ncol(Xcorrupted), 2)
+  Xcorrupted[ind1, ind2] <- NaN 
+  expect_error(grpSLOPE(X=Xcorrupted, y=y, group=grp, fdr=fdr, lambda="corrected"),
+               regexp = "Some entries of X are NA or NaN!")
+  # NA in y
+  ycorrupted <- y
+  ind1 <- sample(1:length(y), 1)
+  ycorrupted[ind1] <- NA
+  expect_error(grpSLOPE(X=A, y=ycorrupted, group=grp, fdr=fdr, lambda="corrected"),
+               regexp = "Some entries of y are NA or NaN!")
+  # NaN in y
+  ycorrupted <- y
+  ind1 <- sample(1:length(y), 3)
+  ycorrupted[ind1] <- NaN 
+  expect_error(grpSLOPE(X=A, y=ycorrupted, group=grp, fdr=fdr, lambda="corrected"),
+               regexp = "Some entries of y are NA or NaN!")
+  # NA in group 
+  grpcorrupted <- grp 
+  ind1 <- sample(1:length(grp), 1)
+  grpcorrupted[ind1] <- NA
+  expect_error(grpSLOPE(X=A, y=y, group=grpcorrupted, fdr=fdr, lambda="corrected"),
+               regexp = "Some entries of group are NA or NaN!")
+  # NaN in group 
+  grpcorrupted <- grp
+  ind1 <- sample(1:length(grp), 3)
+  grpcorrupted[ind1] <- NaN 
+  expect_error(grpSLOPE(X=A, y=y, group=grpcorrupted, fdr=fdr, lambda="corrected"),
+               regexp = "Some entries of group are NA or NaN!")
+})
+
+test_that("an error message is returned when X has constant columns and normalize=TRUE", {
+  # NA in X
+  Xcorrupted <- A
+  ind1 <- sample(1:nrow(Xcorrupted), 1)
+  Xcorrupted[ , ind1] <- rep(rnorm(1), nrow(Xcorrupted)) 
+  expect_error(grpSLOPE(X=Xcorrupted, y=y, group=grp, fdr=fdr, lambda="corrected", normalize=TRUE),
+               regexp = "X cannot be normalized (probably some column has sample variance equal to 0).", fixed=TRUE)
+})
+
 #--------------------------------------------------------------------------
 context("grpSLOPE(lambda = 'corrected', orthogonalize = FALSE)")
 


### PR DESCRIPTION
Addresses #5:

- An error is returned when missing values are present in X, y, or group.
- X cannot be normalized when it has constant columns, so an error is returned.